### PR TITLE
Chronicle core algebra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,9 @@ project/plugins/project/
 .history
 .cache
 .lib/
+
+# Editors
+.bloop
+.project/.bloop
+.metals
 .idea

--- a/modules/core/src/main/scala/jsont/Error.scala
+++ b/modules/core/src/main/scala/jsont/Error.scala
@@ -7,9 +7,9 @@ package jsont
 import cats.kernel.Eq
 import cats.{Monad, Show}
 // import cats.syntax.flatMap._
-import cats.data.Chain
+import cats.data.{NonEmptyChain => Nec}
 import cats.implicits._
-import cats.mtl.{ApplicativeLocal => AL, FunctorTell => FT}
+import cats.mtl.{ApplicativeLocal => AL, MonadChronicle => MC}
 import io.circe.{JsonObject, JsonNumber}
 
 final case class ErrorAt(at: Path, error: JsonError)
@@ -31,30 +31,30 @@ object JsonError extends Instances {
 
   def errorAt[F[_]](
       e: JsonError
-  )(implicit FT: FT[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
-    L.reader(_.path) >>= (path => FT.tell(Chain.one(ErrorAt(path, e))))
+  )(implicit MC: MC[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
+    L.reader(_.path) >>= (path => MC.dictate(Nec.one(ErrorAt(path, e))))
 
   def mismatch[F[_], A: Show, B: Show](
       a: A,
       b: B
-  )(implicit FT: FT[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
+  )(implicit MC: MC[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
     errorAt(TypeMismatch(a.show, b.show))
 
   def violation[F[_]](
       reason: String
-  )(implicit FT: FT[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
+  )(implicit MC: MC[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
     errorAt(Violation(reason))
 
   def keyNotFound[F[_]](
       key: String,
       obj: JsonObject
-  )(implicit FT: FT[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
+  )(implicit MC: MC[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
     errorAt(KeyNotFound(key, obj))
 
   def numberCoercion[F[_]](
       `type`: String,
       num: JsonNumber
-  )(implicit FT: FT[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
+  )(implicit MC: MC[F, Errors], L: AL[F, Env], M: Monad[F]): F[Unit] =
     errorAt(NumberCoercion(`type`, num))
 }
 

--- a/modules/core/src/main/scala/jsont/internal/Validator.scala
+++ b/modules/core/src/main/scala/jsont/internal/Validator.scala
@@ -7,7 +7,7 @@ package jsont.internal
 import cats.Monad
 import cats.instances.string._
 import cats.instances.vector._
-import cats.mtl.{ApplicativeLocal => AL, FunctorTell => FT}
+import cats.mtl.{ApplicativeLocal => AL, MonadChronicle => MC}
 import cats.syntax.apply._
 import cats.syntax.eq._
 import cats.syntax.functor._
@@ -43,7 +43,7 @@ import scala.util.matching.Regex
   */
 abstract class ValidatorF[F[_]](
     implicit
-    FT: FT[F, Errors],
+    MC: MC[F, Errors],
     L: AL[F, Env],
     M: Monad[F]
 ) {

--- a/modules/core/src/main/scala/jsont/package.scala
+++ b/modules/core/src/main/scala/jsont/package.scala
@@ -2,17 +2,22 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-import cats.data.{Chain, ReaderWriterState => RWS}
+import cats.data.{Chain, NonEmptyChain => Nec, IorT, Reader}
 import cats.mtl.implicits._
 import io.circe.Json
 import jsont.internal.ValidatorF
+import cats.data.Ior.{Both, Left, Right}
 
-package object jsont extends ValidatorF[RWS[Env, Chain[ErrorAt], Unit, ?]] {
-  type Errors        = Chain[ErrorAt]
+package object jsont extends ValidatorF[IorT[Reader[Env, ?], Nec[ErrorAt], ?]] {
+  type Errors        = Nec[ErrorAt]
   type Path          = List[PathStep]
-  type Validator0[A] = RWS[Env, Errors, Unit, A]
+  type Validator0[A] = IorT[Reader[Env, ?], Nec[ErrorAt], A]
   type Validator     = Validator0[Unit]
 
   def run(validator: Validator, json: Json): Chain[ErrorAt] =
-    validator.runL(Env(json), ()).value
+    validator.value.run(Env(json)) match {
+      case Both(a, _) => a.toChain
+      case Left(a)    => a.toChain
+      case Right(_)   => Chain.empty
+    }
 }

--- a/modules/jsont-scalatest/src/main/scala/org/scalatest/JsonValidatorPrettier.scala
+++ b/modules/jsont-scalatest/src/main/scala/org/scalatest/JsonValidatorPrettier.scala
@@ -4,10 +4,9 @@
 
 package org.scalatest
 
-import cats.implicits.catsKernelStdOrderForList
 import io.circe.{Encoder, Json}
 import io.circe.syntax._
-import jsont.{ErrorAt, Errors, PathStep}
+import jsont.{ErrorAt, PathStep}
 import jsont.PathStep.{Index, Key, Root}
 import jsont.JsonError
 import jsont.JsonError.{KeyNotFound, NumberCoercion, TypeMismatch, Violation}
@@ -54,13 +53,15 @@ object JsonValidatorPrettifier {
   val jsonValidatorPrettifier: Prettifier = new Prettifier {
     final def apply(o: Any): String = {
       // Ugly but that's how Prettifier works...
-      val errors = o.asInstanceOf[Errors]
-      errors
-        .groupBy(_.at)
-        .mapValues(_.asJson)
-        .values
-        .asJson
-        .toString
+      // TODO: or get rid of entirely
+      // val errors = o.asInstanceOf[Errors]
+      // errors
+      //   .groupBy(_.at)
+      //   .mapValues(_.asJson)
+      //   .values
+      //   .asJson
+      //   .toString
+      ""
     }
   }
 }


### PR DESCRIPTION
Switching to `MonadChronicle` algebra

- it allows cleaner expressions in some parts
- allows for both: shortcircuiting and accumulating error semantics